### PR TITLE
NULL converted to nil

### DIFF
--- a/lsqlite.c
+++ b/lsqlite.c
@@ -502,12 +502,20 @@ static void push_col(lua_State *L, sqlite3_stmt *stmt, int i, int t) {
         case SQLITE_TEXT:
                 tlen = sqlite3_column_bytes(stmt, i);
                 c = sqlite3_column_text(stmt, i);
-                lua_pushlstring(L, c, tlen);
+                if ( NULL == c ) {
+                    lua_pushnil(L);
+                } else {
+                    lua_pushlstring(L, c, tlen);
+                }
                 break;
         case SQLITE_BLOB:
                 tlen = sqlite3_column_bytes(stmt, i);
                 c = (const char*)sqlite3_column_blob(stmt, i);
-                lua_pushlstring(L, c, tlen);
+                if ( NULL == c ) {
+                    lua_pushnil(L);
+                } else {
+                    lua_pushlstring(L, c, tlen);
+                }
                 break;
         case SQLITE_NULL:
                 lua_pushnil(L);

--- a/lsqlite.c
+++ b/lsqlite.c
@@ -660,7 +660,6 @@ SI row_iter_list(lua_State *L) {
                         push_col(L, stmt, i, ci->col[i].type);
                         lua_settable(L, -3);
                 }
-                free(ci);
                 return 1;
         } else {
                 sqlite3_reset(stmt);
@@ -686,7 +685,6 @@ SI row_iter_table(lua_State *L) {
                         push_col(L, stmt, i, ci->col[i].type);
                         lua_settable(L, -3);
                 }
-                free(ci);
                 return 1;
         } else {
                 sqlite3_reset(stmt);

--- a/lsqlite.c
+++ b/lsqlite.c
@@ -660,6 +660,7 @@ SI row_iter_list(lua_State *L) {
                         push_col(L, stmt, i, ci->col[i].type);
                         lua_settable(L, -3);
                 }
+                free(ci);
                 return 1;
         } else {
                 sqlite3_reset(stmt);
@@ -685,6 +686,7 @@ SI row_iter_table(lua_State *L) {
                         push_col(L, stmt, i, ci->col[i].type);
                         lua_settable(L, -3);
                 }
+                free(ci);
                 return 1;
         } else {
                 sqlite3_reset(stmt);


### PR DESCRIPTION
In luajit 2.1, if you push a string that is NULL you get an empty string, so we need logic like this so NULL is converted to nil.
